### PR TITLE
Fixed PurchasingTransactionCreate class name

### DIFF
--- a/src/Functions/Purchasing/PurchasingTransactionCreate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionCreate.ts
@@ -20,7 +20,7 @@
 import IaXmlWriter from "../../Xml/IaXmlWriter";
 import AbstractPurchasingTransaction from "./AbstractPurchasingTransaction";
 
-export default class OrderEntryTransactionCreate extends AbstractPurchasingTransaction {
+export default class PurchasingTransactionCreate extends AbstractPurchasingTransaction {
 
     public writeXml(xml: IaXmlWriter): void {
         xml.writeStartElement("function");


### PR DESCRIPTION
The `PurchasingTransactionCreate` file name was correct, but it was using `OrderEntryTransactionCreate` as the class name.  Since the filename was correct, end users only saw the correct class name.  However, the documentation shows the class name as `OrderEntryTransactionCreate`.  The hotfix should correct the documentation transparently without affecting any users.