### PR TITLE
Add support of fully qualified domain name (FQDN) in the endpoint url.

### DIFF
--- a/src/Credentials/Endpoint.ts
+++ b/src/Credentials/Endpoint.ts
@@ -28,23 +28,30 @@ export default class Endpoint {
 
     public static readonly DOMAIN_NAME = "intacct.com";
 
+    public static readonly FULL_QUALIFIED_DOMAIN_NAME = Endpoint.DOMAIN_NAME + ".";
+
+    private static isDomainValid(hostname: string): boolean {
+        const checkMainDomain = "." + Endpoint.DOMAIN_NAME;
+        const checkFQDNDomain = "." + Endpoint.FULL_QUALIFIED_DOMAIN_NAME;
+        return (hostname.substr(-checkMainDomain.length) === checkMainDomain) ||
+            (hostname.substr(-checkFQDNDomain.length) === checkFQDNDomain);
+    }
     private _url: string;
     get url(): string {
         return this._url;
     }
+
     set url(address: string) {
         if (address == null || address === "") {
             address = Endpoint.DEFAULT_ENDPOINT;
         }
 
-        const test = url.parse(address);
-        const check = "." + Endpoint.DOMAIN_NAME;
-        if (test.hostname.substr(-check.length) !== check) {
+        const parsedUrl = url.parse(address);
+        if (!Endpoint.isDomainValid(parsedUrl.hostname)) {
             throw new Error("Endpoint URL is not a valid " + Endpoint.DOMAIN_NAME + " domain name.");
         }
         this._url = address;
     }
-
     constructor(config: ClientConfig) {
         if (config.endpointUrl == null) {
             this.url = process.env[Endpoint.ENDPOINT_URL_ENV_NAME];

--- a/test/Credentials/EndpointTest.ts
+++ b/test/Credentials/EndpointTest.ts
@@ -78,4 +78,12 @@ describe("Endpoint", () => {
             "Endpoint URL is not a valid intacct.com domain name.",
         );
     });
+
+    it("should allow FQDN Endpoint URL", () => {
+        const config = new ClientConfig();
+        config.endpointUrl = "https://api.intacct.com./ia/xml/xmlgw.phtml";
+        const endpoint = new Endpoint(config);
+
+        chai.assert.equal(endpoint.url, "https://api.intacct.com./ia/xml/xmlgw.phtml");
+    });
 });


### PR DESCRIPTION
Endpoint only allow the "intacct.com" domain.

It turns out on AWS lambda when we try to use the library, the DNS resolution takes more than 15 seconds. Allowing to use a fully qualified domain name (adding a tailing dot to the domain name) help the DNS resolution and remove the 15 extra second for every api call to intacct.

We updated Endpoint to allow the FQDN and added a related unit test case.