### PR TITLE
Quick fix for setting fulfillmentStatus

### DIFF
--- a/src/Functions/OrderEntry/OrderEntryTransactionLineCreate.ts
+++ b/src/Functions/OrderEntry/OrderEntryTransactionLineCreate.ts
@@ -71,7 +71,13 @@ export default class OrderEntryTransactionLineCreate extends AbstractOrderEntryT
         xml.writeElement("employeeid", this.employeeId);
         xml.writeElement("classid", this.classId);
         xml.writeElement("contractid", this.contractId);
-        xml.writeElement("fulfillmentstatus", this.fulfillmentStatus);
+
+        if (this.fulfillmentStatus) {
+            xml.writeStartElement("fulfillmentstatus");
+            xml.writeElement("deliverystatus", this.fulfillmentStatus);
+            xml.writeEndElement(); // fulfillmentstatus
+        }
+
         xml.writeElement("taskno", this.taskNumber);
         xml.writeElement("billingtemplate", this.billingTemplate);
 

--- a/src/Functions/OrderEntry/OrderEntryTransactionLineUpdate.ts
+++ b/src/Functions/OrderEntry/OrderEntryTransactionLineUpdate.ts
@@ -73,7 +73,13 @@ export default class OrderEntryTransactionLineUpdate extends AbstractOrderEntryT
         xml.writeElement("employeeid", this.employeeId);
         xml.writeElement("classid", this.classId);
         xml.writeElement("contractid", this.contractId);
-        xml.writeElement("fulfillmentstatus", this.fulfillmentStatus);
+
+        if (this.fulfillmentStatus) {
+            xml.writeStartElement("fulfillmentstatus");
+            xml.writeElement("deliverystatus", this.fulfillmentStatus);
+            xml.writeEndElement(); // fulfillmentstatus
+        }
+
         xml.writeElement("taskno", this.taskNumber);
         xml.writeElement("billingtemplate", this.billingTemplate);
 

--- a/test/Functions/OrderEntry/OrderEntryTransactionLineCreateTest.ts
+++ b/test/Functions/OrderEntry/OrderEntryTransactionLineCreateTest.ts
@@ -92,7 +92,9 @@ describe("OrderEntryTransactionLineCreate", () => {
         <employeeid>90295</employeeid>
         <classid>243609</classid>
         <contractid>9062</contractid>
-        <fulfillmentstatus>Complete</fulfillmentstatus>
+        <fulfillmentstatus>
+            <deliverystatus>Undelivered</deliverystatus>
+        </fulfillmentstatus>
         <taskno>9850</taskno>
         <billingtemplate>3525</billingtemplate>
     </sotransitem>
@@ -114,7 +116,7 @@ describe("OrderEntryTransactionLineCreate", () => {
         record.revRecStartDate = new Date(2015, 5, 30);
         record.revRecEndDate = new Date(2015, 6, 31);
         record.renewalMacro = "Quarterly";
-        record.fulfillmentStatus = "Complete";
+        record.fulfillmentStatus = "Undelivered";
         record.taskNumber = "9850";
         record.billingTemplate = "3525";
         record.locationId = "SF";

--- a/test/Functions/OrderEntry/OrderEntryTransactionLineUpdateTest.ts
+++ b/test/Functions/OrderEntry/OrderEntryTransactionLineUpdateTest.ts
@@ -93,7 +93,9 @@ describe("OrderEntryTransactionLineUpdate", () => {
         <employeeid>90295</employeeid>
         <classid>243609</classid>
         <contractid>9062</contractid>
-        <fulfillmentstatus>Complete</fulfillmentstatus>
+        <fulfillmentstatus>
+            <deliverystatus>Undelivered</deliverystatus>
+        </fulfillmentstatus>
         <taskno>9850</taskno>
         <billingtemplate>3525</billingtemplate>
     </updatesotransitem>
@@ -116,7 +118,7 @@ describe("OrderEntryTransactionLineUpdate", () => {
         record.revRecStartDate = new Date(2015, 5, 30);
         record.revRecEndDate = new Date(2015, 6, 31);
         record.renewalMacro = "Quarterly";
-        record.fulfillmentStatus = "Complete";
+        record.fulfillmentStatus = "Undelivered";
         record.taskNumber = "9850";
         record.billingTemplate = "3525";
         record.locationId = "SF";


### PR DESCRIPTION
A more full featured fix would allow setting deliverydate, deferralstatus, and kitstatus, however that would be a breaking change because the data type for fulfillmentstatus would change from a string to a class.  This implementation just fixes the broken code by setting fulfillmentstatus into deliverystatus, which is probably what was intended to begin with.