### PR TITLE
Getlist fields / Get API

### DIFF
--- a/src/Functions/Common/Get/Get.ts
+++ b/src/Functions/Common/Get/Get.ts
@@ -1,0 +1,56 @@
+/**
+ * @module Intacct/SDK/Functions/Common/Get
+ */
+
+/**
+ * Copyright 2021 Sage Intacct, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import IaXmlWriter from "../../../Xml/IaXmlWriter";
+import AbstractFunction from "../../AbstractFunction";
+
+export default class Get extends AbstractFunction {
+    public object: string;
+    public key: string;
+    public fields: string[];
+
+    public writeXml(xml: IaXmlWriter): void {
+        if (this.object === undefined) {
+            throw new Error("required parameter 'object' undefined");
+        }
+        if (this.key === undefined) {
+            throw new Error("required parameter 'key' undefined");
+        }
+
+        xml.writeStartElement("function");
+        xml.writeAttribute("controlid", this.controlId, true);
+
+        xml.writeStartElement("get");
+        xml.writeAttribute("object", this.object);
+        xml.writeAttribute("key", this.key);
+
+        // optionally add fields to include in list
+        if (this.fields !== undefined) {
+            xml.writeStartElement("fields");
+            this.fields.forEach((field) => {
+                xml.writeElement("field", field);
+            });
+            xml.writeEndElement(); // fields
+        }
+
+        xml.writeEndElement(); // get_list
+
+        xml.writeEndElement(); // function
+    }
+}

--- a/src/Functions/Common/Get/index.ts
+++ b/src/Functions/Common/Get/index.ts
@@ -1,0 +1,1 @@
+export { default as Get } from "./Get";

--- a/src/Functions/Common/GetList/GetList.ts
+++ b/src/Functions/Common/GetList/GetList.ts
@@ -23,12 +23,23 @@ import AbstractFunction from "../../AbstractFunction";
 export default class GetList extends AbstractFunction {
     public object: string;
 
+    public fields: string[];
+
     public writeXml(xml: IaXmlWriter): void {
         xml.writeStartElement("function");
         xml.writeAttribute("controlid", this.controlId, true);
 
         xml.writeStartElement("get_list");
         xml.writeAttribute("object", this.object);
+
+        // optionally add fields to include in list
+        if (this.fields !== undefined) {
+            xml.writeStartElement("fields");
+            this.fields.forEach((field) => {
+                xml.writeElement("field", field);
+            });
+            xml.writeEndElement(); // fields
+        }
 
         xml.writeEndElement(); // get_list
 

--- a/src/Functions/Common/index.ts
+++ b/src/Functions/Common/index.ts
@@ -5,11 +5,8 @@ export { default as ReadMore } from "./ReadMore";
 export { default as Inspect } from "../Common/Inspect";
 export { default as Lookup } from "../Common/Lookup";
 
+import * as Get from "./Get/index";
 import * as GetList from "./GetList/index";
 import * as Query from "./Query/index";
 import * as NewQuery from "./NewQuery/index";
-export {
-    GetList,
-    Query,
-    NewQuery,
-};
+export { Get, GetList, Query, NewQuery };

--- a/test/Functions/Common/Get/GetTest.ts
+++ b/test/Functions/Common/Get/GetTest.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2020 Sage Intacct, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import * as chai from "chai";
+import Get from "../../../../src/Functions/Common/Get/Get";
+import XmlObjectTestHelper from "../../../Xml/XmlObjectTestHelper";
+
+describe("Get", () => {
+    before((done) => {
+        return done();
+    });
+    beforeEach((done) => {
+        return done();
+    });
+    afterEach((done) => {
+        return done();
+    });
+    after((done) => {
+        return done();
+    });
+
+    it("should get supdoc (attachment)", () => {
+        const expected = `<?xml version="1.0" encoding="utf-8" ?>
+<test>
+    <function controlid="unittest">
+        <get object="supdoc" key="A1234" />
+    </function>
+</test>`;
+
+        const record = new Get("unittest");
+        record.object = "supdoc";
+        record.key = "A1234";
+
+        XmlObjectTestHelper.CompareXml(expected, record);
+    });
+
+    it("should get supdoc (attachment) fields", () => {
+        const expected = `<?xml version="1.0" encoding="utf-8" ?>
+<test>
+    <function controlid="unittest">
+        <get object="supdoc" key="A1234">
+            <fields>
+                <field>supdocid</field>
+                <field>description</field>
+                <field>folder</field>
+            </fields>
+        </get>
+    </function>
+</test>`;
+
+        const record = new Get("unittest");
+        record.object = "supdoc";
+        record.key = "A1234";
+        record.fields = ["supdocid", "description", "folder"];
+
+        XmlObjectTestHelper.CompareXml(expected, record);
+    });
+});

--- a/test/Functions/Common/GetList/GetListTest.ts
+++ b/test/Functions/Common/GetList/GetListTest.ts
@@ -30,6 +30,7 @@ describe("GetList", () => {
     after((done) => {
         return done();
     });
+
     it("should get company info", () => {
         const expected = `<?xml version="1.0" encoding="utf-8" ?>
 <test>
@@ -40,6 +41,27 @@ describe("GetList", () => {
 
         const record = new GetList("unittest");
         record.object = "company_info";
+
+        XmlObjectTestHelper.CompareXml(expected, record);
+    });
+
+    it("should get company info fields", () => {
+        const expected = `<?xml version="1.0" encoding="utf-8" ?>
+<test>
+    <function controlid="unittest">
+        <get_list object="supdoc">
+            <fields>
+                <field>supdocname</field>
+                <field>description</field>
+                <field>folder</field>
+            </fields>
+        </get_list>
+    </function>
+</test>`;
+
+        const record = new GetList("unittest");
+        record.object = "supdoc";
+        record.fields = ["supdocname", "description", "folder"];
 
         XmlObjectTestHelper.CompareXml(expected, record);
     });


### PR DESCRIPTION
## GET_LIST
The SDK for _getlist_ currently does not support optional selection of fields.  This pull requires updates the _getlist_ function to optionally support specifying which fields to include in the _getlist_ results.

## GET
The SDK did not include a function for _get_.  The pull request provides an implementation of _get_, that also supports optionally parameters for specifying which fields to include.

## Unit Tests
Unit tests for both _getlist_ and _get_ are included.  