### PR TITLE
Include fields Task ID and Cost Type ID on Purchasing Transaction Line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@intacct/intacct-sdk",
-  "version": "2.2.1",
+  "name": "@johnathanalves/intacct-sdk",
+  "version": "2.2.3",
   "description": "Sage Intacct SDK for JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Functions/Purchasing/AbstractPurchasingTransactionLine.ts
+++ b/src/Functions/Purchasing/AbstractPurchasingTransactionLine.ts
@@ -47,6 +47,7 @@ export default abstract class AbstractPurchasingTransactionLine implements IXmlO
     public customFields: Array<[string, any]> = [];
     public costTypeId: string;
     public taskId: string;
+    public needByDate: Date;
 
     public abstract writeXml(xml: IaXmlWriter): void;
 }

--- a/src/Functions/Purchasing/AbstractPurchasingTransactionLine.ts
+++ b/src/Functions/Purchasing/AbstractPurchasingTransactionLine.ts
@@ -45,6 +45,8 @@ export default abstract class AbstractPurchasingTransactionLine implements IXmlO
     public classId: string;
     public contractId: string;
     public customFields: Array<[string, any]> = [];
+    public costTypeId: string;
+    public taskId: string;
 
     public abstract writeXml(xml: IaXmlWriter): void;
 }

--- a/src/Functions/Purchasing/PurchasingTransactionCreate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionCreate.ts
@@ -21,77 +21,78 @@ import IaXmlWriter from "../../Xml/IaXmlWriter";
 import AbstractPurchasingTransaction from "./AbstractPurchasingTransaction";
 
 export default class PurchasingTransactionCreate extends AbstractPurchasingTransaction {
+  public writeXml(xml: IaXmlWriter): void {
+    xml.writeStartElement("function");
+    xml.writeAttribute("controlid", this.controlId, true);
 
-    public writeXml(xml: IaXmlWriter): void {
-        xml.writeStartElement("function");
-        xml.writeAttribute("controlid", this.controlId, true);
+    xml.writeStartElement("create_potransaction");
 
-        xml.writeStartElement("create_potransaction");
+    xml.writeElement("transactiontype", this.transactionDefinition, true);
 
-        xml.writeElement("transactiontype", this.transactionDefinition, true);
+    xml.writeStartElement("datecreated");
+    xml.writeDateSplitElements(this.transactionDate, true);
+    xml.writeEndElement(); // datecreated
 
-        xml.writeStartElement("datecreated");
-        xml.writeDateSplitElements(this.transactionDate, true);
-        xml.writeEndElement(); // datecreated
-
-        if (this.glPostingDate != null) {
-            xml.writeStartElement("dateposted");
-            xml.writeDateSplitElements(this.glPostingDate);
-            xml.writeEndElement(); // dateposted
-        }
-
-        xml.writeElement("createdfrom", this.createdFrom);
-        xml.writeElement("vendorid", this.vendorId, true);
-        xml.writeElement("documentno", this.documentNumber);
-
-        xml.writeElement("referenceno", this.referenceNumber);
-        xml.writeElement("vendordocno", this.vendorDocNumber);
-        xml.writeElement("termname", this.paymentTerm);
-
-        if (this.dueDate != null) {
-            xml.writeStartElement("datedue");
-            xml.writeDateSplitElements(this.dueDate, true);
-            xml.writeEndElement(); // datedue
-        }
-
-        xml.writeElement("message", this.message);
-        xml.writeElement("shippingmethod", this.shippingMethod);
-
-        xml.writeStartElement("returnto");
-        xml.writeElement("contactname", this.returnToContactName, true);
-        xml.writeEndElement(); // returnto
-
-        xml.writeStartElement("payto");
-        xml.writeElement("contactname", this.payToContactName, true);
-        xml.writeEndElement(); // payto
-
-        xml.writeElement("supdocid", this.attachmentsId);
-        xml.writeElement("externalid", this.externalId);
-
-        this.writeXmlMultiCurrencySection(xml);
-
-        xml.writeCustomFieldsExplicit(this.customFields);
-
-        xml.writeElement("state", this.state);
-
-        xml.writeStartElement("potransitems");
-        if (this.lines != null && this.lines.length > 0) {
-            for (const line of this.lines) {
-                line.writeXml(xml);
-            }
-        }
-        xml.writeEndElement(); // potransitems
-
-        if (this.subtotals != null && this.subtotals.length > 0) {
-            xml.writeStartElement("subtotals");
-            for (const subtotal of this.subtotals) {
-                subtotal.writeXml(xml);
-            }
-            xml.writeEndElement(); // subtotals
-        }
-
-        xml.writeEndElement(); // create_potransaction
-
-        xml.writeEndElement(); // function
+    if (this.glPostingDate != null) {
+      xml.writeStartElement("dateposted");
+      xml.writeDateSplitElements(this.glPostingDate);
+      xml.writeEndElement(); // dateposted
     }
+
+    xml.writeElement("createdfrom", this.createdFrom);
+    xml.writeElement("vendorid", this.vendorId, true);
+    xml.writeElement("documentno", this.documentNumber);
+
+    xml.writeElement("referenceno", this.referenceNumber);
+    xml.writeElement("vendordocno", this.vendorDocNumber);
+    xml.writeElement("termname", this.paymentTerm);
+
+    if (this.dueDate != null) {
+      xml.writeStartElement("datedue");
+      xml.writeDateSplitElements(this.dueDate, true);
+      xml.writeEndElement(); // datedue
+    }
+
+    xml.writeElement("message", this.message);
+    xml.writeElement("shippingmethod", this.shippingMethod);
+
+    xml.writeStartElement("returnto");
+    xml.writeElement("contactname", this.returnToContactName, true);
+    xml.writeEndElement(); // returnto
+
+    xml.writeStartElement("payto");
+    xml.writeElement("contactname", this.payToContactName, true);
+    xml.writeEndElement(); // payto
+
+    xml.writeElement("supdocid", this.attachmentsId);
+    xml.writeElement("externalid", this.externalId);
+
+    this.writeXmlMultiCurrencySection(xml);
+
+    xml.writeCustomFieldsExplicit(this.customFields);
+
+    xml.writeElement("state", this.state);
+
+    xml.writeElement("projectid", this.projectId);
+
+    xml.writeStartElement("potransitems");
+    if (this.lines != null && this.lines.length > 0) {
+      for (const line of this.lines) {
+        line.writeXml(xml);
+      }
+    }
+    xml.writeEndElement(); // potransitems
+
+    if (this.subtotals != null && this.subtotals.length > 0) {
+      xml.writeStartElement("subtotals");
+      for (const subtotal of this.subtotals) {
+        subtotal.writeXml(xml);
+      }
+      xml.writeEndElement(); // subtotals
+    }
+
+    xml.writeEndElement(); // create_potransaction
+
+    xml.writeEndElement(); // function
+  }
 }

--- a/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
@@ -59,6 +59,10 @@ export default class PurchasingTransactionLineCreate extends AbstractPurchasingT
     xml.writeElement("contractid", this.contractId);
     xml.writeElement("billable", this.billable);
 
+    xml.writeStartElement("needbydate");
+    xml.writeDateSplitElements(this.needByDate, true);
+    xml.writeEndElement(); // needbydate
+
     xml.writeEndElement(); // potransitem
   }
 }

--- a/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
@@ -21,45 +21,44 @@ import IaXmlWriter from "../../Xml/IaXmlWriter";
 import AbstractPurchasingTransactionLine from "./AbstractPurchasingTransactionLine";
 
 export default class PurchasingTransactionLineCreate extends AbstractPurchasingTransactionLine {
+  public writeXml(xml: IaXmlWriter): void {
+    xml.writeStartElement("potransitem");
 
-    public writeXml(xml: IaXmlWriter): void {
-        xml.writeStartElement("potransitem");
+    xml.writeElement("itemid", this.itemId, true);
+    xml.writeElement("itemdesc", this.itemDescription);
+    xml.writeElement("taxable", this.taxable);
+    xml.writeElement("warehouseid", this.warehouseId);
+    xml.writeElement("quantity", this.quantity, true);
+    xml.writeElement("unit", this.unit);
+    xml.writeElement("price", this.price);
+    xml.writeElement("overridetaxamount", this.overrideTaxAmount);
+    xml.writeElement("tax", this.tax);
+    xml.writeElement("locationid", this.locationId);
+    xml.writeElement("departmentid", this.departmentId);
+    xml.writeElement("memo", this.memo);
 
-        xml.writeElement("itemid", this.itemId, true);
-        xml.writeElement("itemdesc", this.itemDescription);
-        xml.writeElement("taxable", this.taxable);
-        xml.writeElement("warehouseid", this.warehouseId);
-        xml.writeElement("quantity", this.quantity, true);
-        xml.writeElement("unit", this.unit);
-        xml.writeElement("price", this.price);
-        xml.writeElement("overridetaxamount", this.overrideTaxAmount);
-        xml.writeElement("tax", this.tax);
-        xml.writeElement("locationid", this.locationId);
-        xml.writeElement("departmentid", this.departmentId);
-        xml.writeElement("memo", this.memo);
-
-        if (this.itemDetails != null && this.itemDetails.length > 0) {
-            xml.writeStartElement("itemdetails");
-            for (const itemDetail of this.itemDetails) {
-                itemDetail.writeXml(xml);
-            }
-            xml.writeEndElement(); // itemdetails
-        }
-
-        xml.writeElement("form1099", this.form1099);
-
-        xml.writeCustomFieldsExplicit(this.customFields);
-
-        xml.writeElement("projectid", this.projectId);
-        xml.writeElement("customerid", this.customerId);
-        xml.writeElement("vendorid", this.vendorId);
-        xml.writeElement("employeeid", this.employeeId);
-        xml.writeElement("classid", this.classId);
-        xml.writeElement("contractid", this.contractId);
-        xml.writeElement("billable", this.billable);
-        xml.writeElement("costtypeid", this.costTypeId);
-        xml.writeElement("taskid", this.taskId);
-
-        xml.writeEndElement(); // potransitem
+    if (this.itemDetails != null && this.itemDetails.length > 0) {
+      xml.writeStartElement("itemdetails");
+      for (const itemDetail of this.itemDetails) {
+        itemDetail.writeXml(xml);
+      }
+      xml.writeEndElement(); // itemdetails
     }
+
+    xml.writeElement("form1099", this.form1099);
+
+    xml.writeCustomFieldsExplicit(this.customFields);
+
+    xml.writeElement("projectid", this.projectId);
+    xml.writeElement("taskid", this.taskId);
+    xml.writeElement("costtypeid", this.costTypeId);
+    xml.writeElement("customerid", this.customerId);
+    xml.writeElement("vendorid", this.vendorId);
+    xml.writeElement("employeeid", this.employeeId);
+    xml.writeElement("classid", this.classId);
+    xml.writeElement("contractid", this.contractId);
+    xml.writeElement("billable", this.billable);
+
+    xml.writeEndElement(); // potransitem
+  }
 }

--- a/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
@@ -58,7 +58,7 @@ export default class PurchasingTransactionLineCreate extends AbstractPurchasingT
         xml.writeElement("contractid", this.contractId);
         xml.writeElement("billable", this.billable);
         xml.writeElement("costtypeid", this.costTypeId);
-        xml.writeElement("taskid", this.taskId)
+        xml.writeElement("taskid", this.taskId);
 
         xml.writeEndElement(); // potransitem
     }

--- a/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionLineCreate.ts
@@ -57,6 +57,8 @@ export default class PurchasingTransactionLineCreate extends AbstractPurchasingT
         xml.writeElement("classid", this.classId);
         xml.writeElement("contractid", this.contractId);
         xml.writeElement("billable", this.billable);
+        xml.writeElement("costtypeid", this.costTypeId);
+        xml.writeElement("taskid", this.taskId)
 
         xml.writeEndElement(); // potransitem
     }

--- a/src/Functions/Purchasing/PurchasingTransactionLineUpdate.ts
+++ b/src/Functions/Purchasing/PurchasingTransactionLineUpdate.ts
@@ -52,6 +52,8 @@ export default class PurchasingTransactionLineUpdate extends AbstractPurchasingT
         xml.writeCustomFieldsExplicit(this.customFields);
 
         xml.writeElement("projectid", this.projectId);
+        xml.writeElement("taskid", this.taskId);
+        xml.writeElement("costtypeid", this.costTypeId);
         xml.writeElement("customerid", this.customerId);
         xml.writeElement("vendorid", this.vendorId);
         xml.writeElement("employeeid", this.employeeId);


### PR DESCRIPTION
Construction companies often use Task Id and Cost Type Id on purchase transaction lines. I noticed this was missing when trying to push a purchasing transaction using the sdk. 