### PR TITLE
feat: Add support for getting an attachment

### DIFF
--- a/src/Functions/Company/AttachmentGet.ts
+++ b/src/Functions/Company/AttachmentGet.ts
@@ -1,0 +1,39 @@
+/**
+ * @module Intacct/SDK/Functions/Company
+ */
+
+/**
+ * Copyright 2022 Sage Intacct, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import IaXmlWriter from "../../Xml/IaXmlWriter";
+import AbstractFunction from "../AbstractFunction";
+
+export default class AttachmentGet extends AbstractFunction {
+    public attachmentsId: string;
+
+    public writeXml(xml: IaXmlWriter): void {
+        xml.writeStartElement("function");
+        xml.writeAttribute("controlid", this.controlId, true);
+
+        xml.writeStartElement("get");
+
+        xml.writeAttribute("object", "supdoc");
+        xml.writeAttribute("key", this.attachmentsId, true);
+
+        xml.writeEndElement(); // get
+
+        xml.writeEndElement(); // function
+    }
+}

--- a/src/Functions/Company/index.ts
+++ b/src/Functions/Company/index.ts
@@ -12,6 +12,7 @@ export { default as AllocationDelete } from "./AllocationDelete";
 export { default as AllocationLine } from "./AllocationLine";
 export { default as AllocationUpdate } from "./AllocationUpdate";
 export { default as AttachmentFile } from "./AttachmentFile";
+export { default as AttachmentGet } from "./AttachmentGet";
 export { default as AttachmentsCreate } from "./AttachmentsCreate";
 export { default as AttachmentsDelete } from "./AttachmentsDelete";
 export { default as AttachmentsFolderCreate } from "./AttachmentsFolderCreate";

--- a/test/Functions/Company/AttachmentGetTest.ts
+++ b/test/Functions/Company/AttachmentGetTest.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2022 Sage Intacct, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import AttachmentGet from "../../../src/Functions/Company/AttachmentGet";
+import XmlObjectTestHelper from "../../Xml/XmlObjectTestHelper";
+
+describe("AttachmentFile", () => {
+    before((done) => {
+        return done();
+    });
+    beforeEach((done) => {
+        return done();
+    });
+    afterEach((done) => {
+        return done();
+    });
+    after((done) => {
+        return done();
+    });
+    it("should build AttachmentGet object", () => {
+        const key = "1234";
+
+        const expected = `<?xml version="1.0" encoding="utf-8" ?>
+<test>
+    <function controlid="unittest">
+        <get object="supdoc" key="${key}" />
+    </function>
+</test>`;
+
+        const record = new AttachmentGet();
+        record.attachmentsId = key;
+        record.controlId = "unittest";
+
+        XmlObjectTestHelper.CompareXml(expected, record);
+    });
+});


### PR DESCRIPTION
This has been tested against Intacct.

One question is whether it should be named `AttachmentGet` or `AttachmentsGet`.

Another question is whether `AttachmentGet` should extend `AbstractAttachment` or not.