### PR TITLE
fix: bump xml2js to 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -385,9 +385,9 @@
       "dev": true
     },
     "@types/xml2js": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
-      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -2034,9 +2034,9 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
     },
     "semver": {
       "version": "6.3.0",
@@ -2574,9 +2574,9 @@
       }
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/mock-fs": "^4.13.0",
     "@types/node": "^14.14.41",
     "@types/uuid": "^8.3.0",
-    "@types/xml2js": "^0.4.8",
+    "@types/xml2js": "^0.4.14",
     "@types/xmlbuilder": "^0.0.32",
     "chai": "~4.2.0",
     "mocha": "^10.0.0",
@@ -77,7 +77,7 @@
     "striptags": "^3.1.1",
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
-    "xml2js": "^0.4.23",
+    "xml2js": "^0.6.2",
     "xmlbuilder": "^12.0.1"
   }
 }


### PR DESCRIPTION
Fixes #120

Resolves https://nvd.nist.gov/vuln/detail/CVE-2023-0842

0.6.2 is backward compatible with 0.4.x (0.5.x introduced a non-backward-compatible fix for the CVE listed above). Therefore, this should be safe to treat as a bugfix version (e.g., 2.2.2).