### PR TITLE
Added "offset" to Result.

### DIFF
--- a/src/Xml/Response/Result.ts
+++ b/src/Xml/Response/Result.ts
@@ -64,6 +64,11 @@ export default class Result {
         return this._numRemaining;
     }
 
+    private _offset: number;
+    get offset(): number {
+        return this._offset;
+    }
+
     private _resultId: string;
     get resultId(): string {
         return this._resultId;
@@ -149,6 +154,10 @@ export default class Result {
 
                 if (dataAttr.hasOwnProperty("numremaining")) {
                     this._numRemaining = parseInt(dataAttr["numremaining"], 10);
+                }
+
+                if (dataAttr.hasOwnProperty("offset")) {
+                    this._offset = parseInt(dataAttr["offset"], 10);
                 }
 
                 if (dataAttr.hasOwnProperty("resultId")) {

--- a/test/Xml/Response/ResultTest.ts
+++ b/test/Xml/Response/ResultTest.ts
@@ -442,7 +442,7 @@ describe("Result", () => {
                 <status>success</status>
                 <function>readByQuery</function>
                 <controlid>818b0a96-3faf-4931-97e6-1cf05818ea44</controlid>
-                <data listtype="class" count="1" totalcount="2" numremaining="1" resultId="myResultId">
+                <data listtype="class" count="1" totalcount="2" numremaining="1" offset="0" resultId="myResultId">
                     <class>
                         <RECORDNO>8</RECORDNO>
                         <CLASSID>C1234</CLASSID>
@@ -471,6 +471,7 @@ describe("Result", () => {
         chai.assert.equal(result.count, 1);
         chai.assert.equal(result.totalCount, 2);
         chai.assert.equal(result.numRemaining, 1);
+        chai.assert.equal(result.offset, 0);
         chai.assert.equal(result.resultId, "myResultId");
         chai.assert.equal(result.data.length, 1);
     });
@@ -497,7 +498,7 @@ describe("Result", () => {
                 <status>success</status>
                 <function>readByQuery</function>
                 <controlid>818b0a96-3faf-4931-97e6-1cf05818ea44</controlid>
-                <data listtype="class" count="2" totalcount="3" numremaining="1" resultId="myResultId">
+                <data listtype="class" count="2" totalcount="3" numremaining="1" offset="0" resultId="myResultId">
                     <class>
                         <RECORDNO>8</RECORDNO>
                         <CLASSID>C1234</CLASSID>
@@ -543,6 +544,7 @@ describe("Result", () => {
         chai.assert.equal(result.count, 2);
         chai.assert.equal(result.totalCount, 3);
         chai.assert.equal(result.numRemaining, 1);
+        chai.assert.equal(result.offset, 0);
         chai.assert.equal(result.resultId, "myResultId");
         chai.assert.equal(result.data.length, 2);
     });


### PR DESCRIPTION
While working with the SDK, I realized that there is no way to get the offset, so if you don't retain that when passing it to the SDK for querying, the value is lost.

* Added a new "private" field, `_offset`, which holds the offset value from the result XML, if it is present.
* Added a public getter for the `_offset` field.
* Updated the constructor so that if the Result XML has an `offset` attribute, it attempts to parse it to an integer and then set it to the `_offset` field.
* Updated ResultTest to add tests for the expected `offset` data.