### PR TITLE
Add missing `ChargeCardTransactionLine` `taskId` property

### DIFF
--- a/src/Functions/CashManagement/AbstractChargeCardTransactionLine.ts
+++ b/src/Functions/CashManagement/AbstractChargeCardTransactionLine.ts
@@ -29,6 +29,7 @@ export default abstract class AbstractChargeCardTransactionLine implements IXmlO
     public departmentId: string;
     public locationId: string;
     public projectId: string;
+    public taskId: string;
     public customerId: string;
     public vendorId: string;
     public employeeId: string;

--- a/src/Functions/CashManagement/ChargeCardTransactionLineCreate.ts
+++ b/src/Functions/CashManagement/ChargeCardTransactionLineCreate.ts
@@ -39,6 +39,7 @@ export default class ChargeCardTransactionLineCreate extends AbstractChargeCardT
         xml.writeElement("vendorid", this.vendorId);
         xml.writeElement("employeeid", this.employeeId);
         xml.writeElement("projectid", this.projectId);
+        xml.writeElement("taskid", this.taskId);
         xml.writeElement("itemid", this.itemId);
         xml.writeElement("classid", this.classId);
         xml.writeElement("contractid", this.contractId);


### PR DESCRIPTION
Two line changes

Just add support for setting task id's when creating `ChargeCardTransactionLine`'s 